### PR TITLE
update wakuv2 fleet DNS discovery enrtree

### DIFF
--- a/docs/guides/nwaku/configure-discovery.md
+++ b/docs/guides/nwaku/configure-discovery.md
@@ -46,7 +46,7 @@ For instance, consider a `nwaku` node that enables `DNS Discovery`, connects to 
 ```bash
 ./build/wakunode2 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im \
   --dns-discovery-name-server:1.1.1.1 \
   --dns-discovery-name-server:1.0.0.1
 ```

--- a/docs/guides/nwaku/run-docker.md
+++ b/docs/guides/nwaku/run-docker.md
@@ -46,7 +46,7 @@ Run `nwaku` using the most typical configuration:
 ```bash
 docker run -i -t -p 60000:60000 -p 9000:9000/udp statusteam/nim-waku \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im \
   --discv5-discovery \
   --nat:extip:[YOUR PUBLIC IP] # or, if you are behind a nat: --nat=any
 ```


### PR DESCRIPTION
Enrtrees were regenerated. Need to update the old one.
DNS discoverty should continue to work.
